### PR TITLE
added an export script that reads db settings from dspace.cfg

### DIFF
--- a/bin/exportdb.sh
+++ b/bin/exportdb.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+. /vagrant/etc/conf.sh
+
+
+
+
+
+export PGPASSWORD=$DS_DB_PASS
+pg_dump --encoding utf8 -ocv -U "$DS_DB_USER" -h "$DS_DB_HOST"  "$DS_DB" > "$DB_EXPORT"

--- a/etc/shareok.conf.sh
+++ b/etc/shareok.conf.sh
@@ -21,4 +21,13 @@ DB_ADMIN_PASS=libacct
 DB_NAME=dspace
 DB_PASS=dspace
 
+DB_EXPORT="/vagrant/downloads/shareok-${MAVEN_PROFILE}-dump.sql"
 
+# Read database config from dspace config
+DS_CFG="${DSPACE_RUN}/config/dspace.cfg"
+DS_DB_URL=`cat $DS_CFG | grep ^db.url | cut -d "=" -f 2 | xargs`
+DS_DB_HOST=`echo $DS_DB_URL | cut -d "/" -f 3 | cut -d ":" -f 1`
+DS_DB_PORT=`echo $DS_DB_URL | cut -d "/" -f 3 | cut -d ":" -f 2`
+DS_DB=`echo $DS_DB_URL | cut -d "/" -f 4 | xargs`
+DS_DB_USER=`cat $DS_CFG | grep ^db.username | cut -d "=" -f 2 | xargs`
+DS_DB_PASS=`cat $DS_CFG | grep ^db.password | cut -d "=" -f 2 | xargs`

--- a/scripts/dspace.sh
+++ b/scripts/dspace.sh
@@ -3,11 +3,10 @@
 . /vagrant/etc/conf.sh
 
 
-# make the dspace web app location 
-mkdir -p  "$DSPACE_RUN"
-
-# make the dapce data dir
-mkdir -p "$DSPACE_DATA"
+# make the dspace web app and data dirs
+mkdir -p "$DSPACE_RUN"
+mkdir -p "$DSPACE_DATA" 
+chown -R tomcat:tomcat "$DSPACE_RUN" "$DSPACE_DATA"
 
 # point tomcat at the dspace web app location
 cp -r /vagrant/etc/Catalina/localhost/*.xml /usr/share/tomcat/conf/Catalina/localhost


### PR DESCRIPTION
Moving this from a provision script to a command line utility so that we'll still have it after we move from bash provisioners to ansible. Also, made sure that the dspace data dir gets created with the right permissions. 
